### PR TITLE
Use stable `platformVersion` and normalize Jira endpoint URL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ pluginUntilBuild = 221.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = LATEST-EAP-SNAPSHOT
+platformVersion = 2022.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/java/com/alisli/intelligenthistory/services/JiraFetcherService.java
+++ b/src/main/java/com/alisli/intelligenthistory/services/JiraFetcherService.java
@@ -74,7 +74,7 @@ public final class JiraFetcherService {
                 issueMetadata.setReporter(issue.getReporter().getDisplayName());
                 issueMetadata.setAssignee(issue.getAssignee().getDisplayName());
                 issueMetadata.setPriority(issue.getPriority().toString());
-                issueMetadata.setUrl(config.getEndpointURL() + "/browse/" + issueKey);
+                issueMetadata.setUrl(config.getEndpointURL().replaceAll("/$", "") + "/browse/" + issueKey);
                 issueMetadata.setIssueLinks(issue.getIssueLinks().size());
                 issueMetadata.setSubTasks(issue.getSubtasks().size());
                 issueMetadata.setVotes(issue.getVotes().getVotes());


### PR DESCRIPTION
* Update `platformVersion` to `2022.1.1` rather than `LATEST-EAP-SNAPSHOT`.
* Remove trailing `/` from Jira endpoint URL.