### PR TITLE
Update plugin compatibility for IntelliJ 2022.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.0.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 221
+pluginSinceBuild = 222
 pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ pluginVersion = 1.0.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 221
-pluginUntilBuild = 221.*
+pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.1.1
+platformVersion = LATEST-EAP-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/java/com/alisli/intelligenthistory/highlighters/ImportantCommitsHighlighter.java
+++ b/src/main/java/com/alisli/intelligenthistory/highlighters/ImportantCommitsHighlighter.java
@@ -31,8 +31,9 @@ public class ImportantCommitsHighlighter implements VcsLogHighlighter {
     }
 
     @Override
-    public @NotNull VcsCommitStyle getStyle(int commitId, @NotNull VcsShortCommitDetails commitDetails,
-                                            boolean isSelected) {
+    @NotNull
+    public VcsCommitStyle getStyle(int commitId, @NotNull VcsShortCommitDetails commitDetails,
+                                   int column, boolean isSelected) {
         if (!myImportantCommits.contains(commitId)) {
             return VcsCommitStyleFactory.foreground(TRIVIAL_COMMIT_FOREGROUND);
         }


### PR DESCRIPTION
* Updated the method signature for one of the `getStyle` method defined in the `VcsLogHighlighter` interface.