### PR TITLE
Support platform version 2022.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Intelligent History Changelog
 
+## [Unreleased]
+
 ## [1.0.2] - 2022-6-27
 ### Added
 * Markdown rendering for Jira issue description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 # Intelligent History Changelog
 
-## [Unreleased]
+## [1.0.2] - 2022-6-27
+### Added
+* Markdown rendering for Jira issue description
+
+### Changed
+* JetBrains Marketplace availability in README
+* Vendor email in plugin configuration file
 
 ## [1.0.1] - 2022-6-21
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.6.0"
+    id("org.jetbrains.intellij") version "1.7.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = com.alisli.intelligenthistory
 pluginName = Intelligent History
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.2
+pluginVersion = 1.0.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 221
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.1.3
+platformVersion = 2022.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.0.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 221
+pluginSinceBuild = 222
 pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.alisli.intelligenthistory
 pluginName = Intelligent History
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.3
+pluginVersion = 2.0.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/alisli/intelligenthistory/components/JiraIssuePanelFactory.java
+++ b/src/main/java/com/alisli/intelligenthistory/components/JiraIssuePanelFactory.java
@@ -30,7 +30,7 @@ public class JiraIssuePanelFactory implements ToolWindowFactory, DumbAware {
         }
         JBScrollPane toolWindowContent = new JBScrollPane(toolWindowBuilder.getContent());
         toolWindowContent.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+        ContentFactory contentFactory = ContentFactory.getInstance();
         Content content = contentFactory.createContent(toolWindowContent, displayName, false);
         content.setPreferredFocusableComponent(toolWindowContent);
         content.setDisposer(toolWindowBuilder);

--- a/src/main/java/com/alisli/intelligenthistory/highlighters/ImportantCommitsHighlighter.java
+++ b/src/main/java/com/alisli/intelligenthistory/highlighters/ImportantCommitsHighlighter.java
@@ -32,7 +32,7 @@ public class ImportantCommitsHighlighter implements VcsLogHighlighter {
 
     @Override
     public @NotNull VcsCommitStyle getStyle(int commitId, @NotNull VcsShortCommitDetails commitDetails,
-                                            boolean isSelected) {
+                                            int column, boolean isSelected) {
         if (!myImportantCommits.contains(commitId)) {
             return VcsCommitStyleFactory.foreground(TRIVIAL_COMMIT_FOREGROUND);
         }


### PR DESCRIPTION
* Address changes in platform version 2022.2
* Restrict compatibility to 2022.2 due to API changes in `VcsLogHighlighter` interface
* Bump plugin version to 2.0.0 due to breaking backward compatibility with IntelliJ 2022.1